### PR TITLE
添加setActive方法；

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,10 @@ PerfectVolumeControl.stream.listen((volume) {
   print(volume);
 });
 ````
+````dart
+PerfectVolumeControl.active = true;
+PerfectVolumeControl.active = false;
+````
 
 # Other Plugins
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -72,7 +72,7 @@ class _MyAppState extends State<MyApp> {
                         child: Text("getVolume"),
                         onPressed: () async {
                           double volume =
-                              await PerfectVolumeControl.getVolume();
+                          await PerfectVolumeControl.getVolume();
                           _textEditingController.text = "$volume";
                         },
                       ),
@@ -88,7 +88,21 @@ class _MyAppState extends State<MyApp> {
                         onPressed: () async {
                           await PerfectVolumeControl.setVolume(0.3);
                           _textEditingController.text =
-                              "setVolume to 0.3 finish";
+                          "setVolume to 0.3 finish";
+                        },
+                      ),
+                      OutlinedButton(
+                        child: Text("setActive true 获取音频焦点"),
+                        onPressed: () async {
+                          PerfectVolumeControl.setActive = true;
+                          _textEditingController.text = "setActive true";
+                        },
+                      ),
+                      OutlinedButton(
+                        child: Text("setActive false 放弃音频焦点"),
+                        onPressed: () async {
+                          PerfectVolumeControl.setActive = false;
+                          _textEditingController.text = "setActive false";
                         },
                       ),
                     ],

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "2.6.1"
+    version: "2.8.2"
   boolean_selector:
     dependency: transitive
     description:
@@ -21,14 +21,14 @@ packages:
       name: characters
       url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0"
   charcode:
     dependency: transitive
     description:
       name: charcode
       url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.1"
   clock:
     dependency: transitive
     description:
@@ -42,7 +42,7 @@ packages:
       name: collection
       url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "1.15.0"
+    version: "1.16.0"
   cupertino_icons:
     dependency: "direct main"
     description:
@@ -56,7 +56,7 @@ packages:
       name: fake_async
       url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.0"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -73,28 +73,35 @@ packages:
       name: matcher
       url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "0.12.10"
+    version: "0.12.11"
+  material_color_utilities:
+    dependency: transitive
+    description:
+      name: material_color_utilities
+      url: "https://pub.flutter-io.cn"
+    source: hosted
+    version: "0.1.4"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "1.3.0"
+    version: "1.7.0"
   path:
     dependency: transitive
     description:
       name: path
       url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.1"
   perfect_volume_control:
     dependency: "direct main"
     description:
       path: ".."
       relative: true
     source: path
-    version: "1.0.2"
+    version: "1.0.5"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -106,7 +113,7 @@ packages:
       name: source_span
       url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "1.8.1"
+    version: "1.8.2"
   stack_trace:
     dependency: transitive
     description:
@@ -141,21 +148,14 @@ packages:
       name: test_api
       url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "0.3.0"
-  typed_data:
-    dependency: transitive
-    description:
-      name: typed_data
-      url: "https://pub.flutter-io.cn"
-    source: hosted
-    version: "1.3.0"
+    version: "0.4.9"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
       url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.2"
 sdks:
-  dart: ">=2.12.0 <3.0.0"
+  dart: ">=2.17.0-0 <3.0.0"
   flutter: ">=1.20.0"

--- a/ios/Classes/SwiftPerfectVolumeControlPlugin.swift
+++ b/ios/Classes/SwiftPerfectVolumeControlPlugin.swift
@@ -32,6 +32,9 @@ public class SwiftPerfectVolumeControlPlugin: NSObject, FlutterPlugin {
         case "hideUI":
             self.hideUI(call, result: result);
             break;
+        case "setActive":
+            self.setActive(call, result: result);
+            break;
         default:
             result(FlutterMethodNotImplemented);
         }
@@ -41,7 +44,7 @@ public class SwiftPerfectVolumeControlPlugin: NSObject, FlutterPlugin {
     /// 获得系统当前音量
     public func getVolume(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
         do {
-            try AVAudioSession.sharedInstance().setActive(true)
+//             try AVAudioSession.sharedInstance().setActive(true)
             result(AVAudioSession.sharedInstance().outputVolume);
         } catch let error as NSError {
             result(FlutterError(code: String(error.code), message: "\(error.localizedDescription)", details: "\(error.localizedDescription)"));
@@ -82,10 +85,20 @@ public class SwiftPerfectVolumeControlPlugin: NSObject, FlutterPlugin {
         result(nil);
     }
 
+    /// 设置active，音频焦点与混音等状态
+    public func setActive(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
+        do{
+            let active = ((call.arguments as! [String: Any])["active"]) as! Bool;
+            try AVAudioSession.sharedInstance().setActive(active)
+        }catch let error as NSError{
+            print("\(error)")
+        }
+    }
+
     /// 绑定监听器
     public func bindListener() {
         do {
-            try AVAudioSession.sharedInstance().setActive(true)
+//             try AVAudioSession.sharedInstance().setActive(false)
             AVAudioSession.sharedInstance().addObserver(self, forKeyPath: "outputVolume", options: [.new, .old], context: nil)
         } catch let error as NSError {
             print("\(error)")
@@ -94,7 +107,7 @@ public class SwiftPerfectVolumeControlPlugin: NSObject, FlutterPlugin {
         // 绑定音量监听器
         NotificationCenter.default.addObserver(self, selector: #selector(self.volumeChangeListener), name: NSNotification.Name(rawValue: "AVSystemController_SystemVolumeDidChangeNotification"), object: nil)
         UIApplication.shared.beginReceivingRemoteControlEvents();
-        
+
     }
 
     /// 音量监听
@@ -102,7 +115,7 @@ public class SwiftPerfectVolumeControlPlugin: NSObject, FlutterPlugin {
         let volume = notification.userInfo!["AVSystemController_AudioVolumeNotificationParameter"] as! Float
         channel?.invokeMethod("volumeChangeListener", arguments: volume)
     }
-    
+
     /// 音量监听(KVO方式)
     public override func observeValue(forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey : Any]?, context: UnsafeMutableRawPointer?) {
         let volume = AVAudioSession.sharedInstance().outputVolume

--- a/lib/perfect_volume_control.dart
+++ b/lib/perfect_volume_control.dart
@@ -4,12 +4,12 @@ import 'package:flutter/services.dart';
 
 class PerfectVolumeControl {
   static const MethodChannel _channel =
-      const MethodChannel('perfect_volume_control');
+  const MethodChannel('perfect_volume_control');
 
   /// 音量改变监听器流
   /// Volume change monitor flow
   static StreamController<double> _streamController =
-      StreamController.broadcast();
+  StreamController.broadcast();
 
   /// 音量改变监听器名称
   /// Volume change monitor name
@@ -52,5 +52,11 @@ class PerfectVolumeControl {
   static Future<void> setVolume(double volume) async {
     assert(volume >= 0 && volume <= 1);
     return await _channel.invokeMethod('setVolume', {"volume": volume});
+  }
+
+  /// 设置[active]模式 默认 false 不占用音频焦点 当设置为 true，会暂停其他音频
+  /// Set active mode Default false Does not occupy audio focus When set to true, other audio is paused
+  static set setActive(bool active) {
+    _channel.invokeMethod('setActive', {"active": active});
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "2.5.0"
+    version: "2.8.2"
   boolean_selector:
     dependency: transitive
     description:
@@ -21,14 +21,14 @@ packages:
       name: characters
       url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0"
   charcode:
     dependency: transitive
     description:
       name: charcode
       url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.1"
   clock:
     dependency: transitive
     description:
@@ -42,14 +42,14 @@ packages:
       name: collection
       url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "1.15.0"
+    version: "1.16.0"
   fake_async:
     dependency: transitive
     description:
       name: fake_async
       url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.0"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -66,21 +66,28 @@ packages:
       name: matcher
       url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "0.12.10"
+    version: "0.12.11"
+  material_color_utilities:
+    dependency: transitive
+    description:
+      name: material_color_utilities
+      url: "https://pub.flutter-io.cn"
+    source: hosted
+    version: "0.1.4"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "1.3.0"
+    version: "1.7.0"
   path:
     dependency: transitive
     description:
       name: path
       url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.1"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -92,7 +99,7 @@ packages:
       name: source_span
       url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.2"
   stack_trace:
     dependency: transitive
     description:
@@ -127,21 +134,14 @@ packages:
       name: test_api
       url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "0.2.19"
-  typed_data:
-    dependency: transitive
-    description:
-      name: typed_data
-      url: "https://pub.flutter-io.cn"
-    source: hosted
-    version: "1.3.0"
+    version: "0.4.9"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
       url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.2"
 sdks:
-  dart: ">=2.12.0 <3.0.0"
+  dart: ">=2.17.0-0 <3.0.0"
   flutter: ">=1.20.0"


### PR DESCRIPTION
实例：我依赖了 FlutterPerfectVolumeControl 插件，当我在听歌时，打开我的App，则会中断我的音乐播放。
原因：当plugin 调用 register()时，会调用AVAudioSession.sharedInstance().setActive(true)方法，如果此时其他音频正在播放音乐(QQ音乐)，则会暂停其他音频。
解决方案：把设置 setActive() 方法提取出来作为公共方法，让开发人员自由选择，默认false 不做处理。
setActive(true) 抢夺音频焦点，中断其他音频，
setActive(false)不会抢夺音频焦点
建议：我只是简单处理了一下，还有其他 Category，需要设置。